### PR TITLE
Change pre-commit python version to 3.7 to be inline with the python version used in the CI docker image

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,4 +22,4 @@ repos:
     rev: 19.10b0
     hooks:
     - id: black
-      language_version: python3.8
+      language_version: python3.7


### PR DESCRIPTION
Change pre-commit python version to 3.7 to be inline with the python version used in the CI docker image