### PR TITLE
remove initial setup dynamodb circular dependency

### DIFF
--- a/snowflake/infra/pipes/example-pipe/outputs.tf
+++ b/snowflake/infra/pipes/example-pipe/outputs.tf
@@ -1,5 +1,5 @@
-# output "debug" {
-#   value = {
-#     config = module.config.entries
-#   }
-# }
+output "debug" {
+  value = {
+    config = module.config.entries
+  }
+}


### PR DESCRIPTION
- Remove initial setup dynamodb lock table circular dependency from backend config
