### PR TITLE
update ci to use github container registry

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -5,10 +5,11 @@ on:
     paths:
       - 'project_setup.py'
       - 'tests/**'
+      - './.github/workflows/integration-tests.yml'
 jobs:
   run-tests:
     runs-on: ubuntu-latest
-    container: infinityworks/awscli-terraform-snowflake:1.1.0
+    container: ghcr.io/infinityworks/awscli-terraform-snowflake:1.1.0
     env:
       ENV: dev
 

--- a/aws/sns/SNS.md
+++ b/aws/sns/SNS.md
@@ -1,0 +1,3 @@
+# SNS for Snowpipe error notifications
+
+To understand when things go wrong in a Snowpipe and be alerted to unexpected behavior, we use SNS topics in combination with Cloudwatch.

--- a/aws/sns/backend.tf
+++ b/aws/sns/backend.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_version = ">= 1.3.4"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "4.39.0"
+    }
+    snowflake = {
+      source  = "Snowflake-Labs/snowflake"
+      version = "0.50.0"
+    }
+  }
+
+  backend "s3" {
+    bucket         = "snow-cannon-remote-state"
+    dynamodb_table = "snow-cannon-lock-table"
+    key            = "aws/sns/terraform.tfstate"
+    region         = "eu-west-2"
+    encrypt        = true
+  }
+
+}

--- a/aws/sns/error-notification-channel.tf
+++ b/aws/sns/error-notification-channel.tf
@@ -1,0 +1,3 @@
+resource "aws_sns_topic" "snowpipe_error_notifaction_channel" {
+  name = "snowpipe-error-notification-channel"
+}

--- a/aws/sns/error-notification-role.tf
+++ b/aws/sns/error-notification-role.tf
@@ -1,0 +1,46 @@
+resource "aws_iam_role" "snow_pipe_error_notification_channel" {
+  name                 = "${local.project_name}-snowpipe-error-notification-channel-${local.config.env_formatted.lower}"
+  permissions_boundary = var.permissions_boundary
+  path                 = var.path
+  assume_role_policy   = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::282654190546:user/1nyk-s-iess3910"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "sts:ExternalId": "INFINITYWORKSPARTNER_SFCRole=4_hf+IQekCiQYAJOXOaP7Qbeve4P4="
+        }
+      }
+    }
+  ]
+}
+EOF
+  tags = {
+    Description = "Role for Programmatic user to adopt for CI deployments"
+  }
+}
+
+resource "aws_iam_role_policy" "snow_pipe_error_notification_channel" {
+  name   = "${local.project_name}-snowpipe-error-notification-channel-${local.config.env_formatted.lower}"
+  policy = data.aws_iam_policy_document.snow_pipe_error_notification_channel.json
+  role   = aws_iam_role.snow_pipe_error_notification_channel.id
+}
+
+data "aws_iam_policy_document" "snow_pipe_error_notification_channel" {
+  statement {
+    sid       = ""
+    effect    = "Allow"
+    resources = [aws_sns_topic.snowpipe_error_notifaction_channel.arn]
+
+    actions = [
+      "sns:Publish"
+    ]
+  }
+}

--- a/aws/sns/locals.tf
+++ b/aws/sns/locals.tf
@@ -1,0 +1,7 @@
+locals {
+  config = module.config.entries
+}
+
+locals {
+  project_name = module.config.entries.main.project_name
+}

--- a/aws/sns/outputs.tf
+++ b/aws/sns/outputs.tf
@@ -1,0 +1,5 @@
+output "debug" {
+  value = {
+    config = module.config.entries
+  }
+}

--- a/aws/sns/providers.tf
+++ b/aws/sns/providers.tf
@@ -1,0 +1,14 @@
+module "config" {
+  source         = "../../terraform-config"
+  workspace_name = terraform.workspace
+}
+
+provider "aws" {
+  region = module.config.entries.providers.aws_region
+  default_tags {
+    tags = {
+      Project     = local.project_name
+      Environment = local.config.main.env
+    }
+  }
+}

--- a/aws/sns/snowflake-notification-integration.tf
+++ b/aws/sns/snowflake-notification-integration.tf
@@ -1,0 +1,30 @@
+resource "snowflake_notification_integration" "snowpipe_error_channel" {
+  name    = "snowpipe_error_channel"
+  comment = "${local.project_name} notification integration."
+
+  enabled   = true
+  type      = "QUEUE"
+  direction = "OUTBOUND"
+
+
+  # AWS_SQS
+  #notification_provider = "AWS_SQS"
+  #aws_sqs_arn           = "..."
+  #aws_sqs_role_arn      = "..."
+
+
+  notification_provider = "AWS_SNS"
+  aws_sns_topic_arn     = aws_sns_topic.snowpipe_error_notifaction_channel.arn
+  aws_sns_role_arn      = aws_iam_role.snow_pipe_error_notification_channel.arn
+}
+
+#  resource "snowflake_pipe" "create_pipe" {
+#   name           = "T_DATA_PIPE"
+#   auto_ingest    = "true"
+#   database       = "ANALYTICS"
+#   schema         = "PUBLIC"
+#   copy_statement = "COPY INTO ANALYTICS.PUBLIC.TRANSACTIONS from ( SELECT $1, TO_TIMESTAMP_NTZ(current_timestamp) FROM @ANALYTICS.PUBLIC.TRANSACTIONS_EXTERNAL_STAGE) file_format = (type = 'JSON'      )"
+# #   aws_sns_topic_arn   = aws_sns_topic.snowpipe_error_notifaction_channel.arn
+#   error_integration = snowflake_notification_integration.snowpipe_error_channel.name
+#   comment        = "Pipe to ingest data "
+# }

--- a/aws/sns/test.csv
+++ b/aws/sns/test.csv
@@ -1,0 +1,8 @@
+{
+  "CUSTOMER": {
+    "description": "this is the customer",
+    "short_name": "CUST"
+  },
+  "PRODUCT": "PRDCT",
+  "TRANSACTION": "TRNSCTN"
+}

--- a/aws/sns/variables.tf
+++ b/aws/sns/variables.tf
@@ -1,0 +1,21 @@
+variable "workspace_name" {
+  # (https://github.com/hashicorp/terraform/issues/22802)"
+  default     = "dev"
+  description = "The actual name of the cloud workspace must be passed in when running inside terraform cloud. This variable should only be set within a workspace defined within terraform cloud."
+  type        = string
+}
+
+variable "permissions_boundary" {
+  description = "The IAM role permission boundary"
+  default     = null
+}
+
+variable "path" {
+  description = "IAM role path"
+  default     = null
+}
+
+variable "owner" {
+  description = "The owner of this resource"
+  default     = ""
+}

--- a/snowflake/infra/pipes/example-pipe/example_pipe.tf
+++ b/snowflake/infra/pipes/example-pipe/example_pipe.tf
@@ -5,3 +5,15 @@ module "example_pipe" {
   database       = "ANALYTICS"
   schema         = "PUBLIC"
 }
+
+module "test_pipe_to_fail" {
+  source           = "../../../modules/snowpipe-module/"
+  s3_bucket_name   = "snow-cannon-data-lake-${local.config.env_formatted.lower}"
+  s3_path          = "customers"
+  database         = "ANALYTICS"
+  schema           = "PUBLIC"
+  file_format      = "CSV"
+  field_delimiter  = "\t"
+  record_delimiter = "\n"
+  filter_suffix    = ".csv"
+}

--- a/snowflake/infra/pipes/example-pipe/table-definition.csv
+++ b/snowflake/infra/pipes/example-pipe/table-definition.csv
@@ -1,0 +1,3 @@
+field,type
+col1,INTEGER
+col2,VARCHAR

--- a/snowflake/modules/snowpipe-module/pipes.md
+++ b/snowflake/modules/snowpipe-module/pipes.md
@@ -1,0 +1,10 @@
+# Testing: How to force an error
+
+To test the error notification channel works as expected, you can force an error by deploying a pipe with a normalised set of columns (using `table-definitions.csv`) and create a file in s3 with a different schema, ie contains a header when one was not expected. This should yield a COPY error which can be found with.
+
+
+```
+select *
+from "SNOWFLAKE"."ACCOUNT_USAGE"."COPY_HISTORY"
+where file_name = 'table-definition.csv';
+```


### PR DESCRIPTION
- Update GitHub actions container image to infinityworks/awscli-terraform-snowflake:1.1.0 (hosted in Docker Hub)
- create sns topic for snowpipe error notifications
- Create test case to measure pipe error using unexpected file schema
- Swap CI container from Dockerhub to GitHub container registry
